### PR TITLE
Use explicit export list

### DIFF
--- a/src/Language/Elm/Pretty.hs
+++ b/src/Language/Elm/Pretty.hs
@@ -1,3 +1,4 @@
+{-# language LambdaCase #-}
 {-# language OverloadedStrings #-}
 {-# language ViewPatterns #-}
 module Language.Elm.Pretty
@@ -92,8 +93,21 @@ module_ mname defs =
       HashSet.map (\(Name.Qualified m _) -> m) $
       HashSet.filter (isNothing . defaultImport) $
       foldMap (Definition.foldMapGlobals HashSet.singleton) defs
+
+    exports =
+      indent 4 $
+      (<> line <> ")") $
+      vsep $
+      zipWith (<>) ("( " : repeat ", ") $
+      map export defs
+
+    export = \case
+      Definition.Constant (Name.Qualified _ name) _ _ _ -> pretty name
+      Definition.Type (Name.Qualified _ name) _ _ -> pretty name <> "(..)"
+      Definition.Alias (Name.Qualified _ name) _ _ -> pretty name
+
   in
-  "module" <+> moduleName mname <+> "exposing (..)" <> line <> line <>
+  "module" <+> moduleName mname <+> "exposing" <> line <> exports <> line <> line <>
   mconcat ["import" <+> moduleName import_ <> line | import_ <- imports] <> line <> line <>
   mconcat (intersperse (line <> line <> line) [definition env def | def <- defs])
 


### PR DESCRIPTION
Closes folq/haskell-to-elm#8.

Potential bike-shedding:

- Pretty printing: I've mimicked what `elm-format` does for lists that don't fit on a single line. We could provide a special case so that exports are written on one line when possible (I think `prettyprinter` makes this quite easy), but there doesn't seem much point.
- I'm in the habit of using `LambdaCase` far more than traditional `case` syntax, but you may have reasons for wanting to avoid unnecessary extensions.
- This could be made optional, but I don't see any real downside to having it always enabled.