### PR TITLE
Fix for GHC 9.0

### DIFF
--- a/src/Language/Elm/Expression.hs
+++ b/src/Language/Elm/Expression.hs
@@ -94,13 +94,13 @@ bind global var expression =
       bind (fmap F . global) (unvar (pure . B) (fmap F . var)) .
       fromScope
 
-deriving instance Eq v => Eq (Expression v)
-deriving instance Ord v => Ord (Expression v)
-deriving instance Show v => Show (Expression v)
-
 deriveEq1 ''Expression
 deriveOrd1 ''Expression
 deriveShow1 ''Expression
+
+deriving instance Eq v => Eq (Expression v)
+deriving instance Ord v => Ord (Expression v)
+deriving instance Show v => Show (Expression v)
 
 instance IsString (Expression v) where
   fromString = Global . fromString


### PR DESCRIPTION
From [release notes](https://downloads.haskell.org/ghc/9.0.1/docs/html/users_guide/9.0.1-notes.html):

> Breaking change: Template Haskell splices now act as separation points between constraint solving passes. It is no longer possible to use an instance of a class before a splice and define that instance after a splice.

